### PR TITLE
Add fixtures for book objects

### DIFF
--- a/frontend/src/fixtures/bookFixtures.js
+++ b/frontend/src/fixtures/bookFixtures.js
@@ -1,0 +1,42 @@
+const bookFixtures = {
+    onebook:
+    [
+      {
+       "id": 1,
+        "title": "The Lord of the Rings",
+        "author": "J.R.R. Tolkien",
+        "description": "A story about a group of heroes who set forth on a journey to save the world.",
+        "genre": "Fantasy",  
+      }
+    ],
+
+    threebooks:
+    [
+        {
+            "id": 2,
+             "title": "Animal Farm",
+             "author": "George Orwell",
+             "description": "A story about a group of farm animals who rebel against their human farmer, hoping to create a society where the animals can be equal, free, and happy.",
+             "genre": "Fable",    
+        },
+
+        {
+            "id": 3,
+             "title": "Fahrenheit 451",
+             "author": "Ray Bradbury",
+             "description": "A story set in a dystopian society that burns books in order to control the thoughts of its citizens.",
+             "genre": "Dystopian fiction",
+        },
+
+        {
+            "id": 4,
+             "title": "The Great Gatsby",
+             "author": "F. Scott Fitzgerald",
+             "description": "A tragic story of Jay Gatsby, a self-made millionaire, and his pursuit of Daisy Buchanan, a wealthy young woman whom he loved in his youth.",
+             "genre": "Tragedy",      
+        },
+        
+    ]
+};
+
+export { bookFixtures };


### PR DESCRIPTION
In this PR, we add fixtures for book objects to be used in testing and storybook entries.
